### PR TITLE
Client: GetBlockByNumber method returns tx object

### DIFF
--- a/packages/client/lib/rpc/modules/eth.ts
+++ b/packages/client/lib/rpc/modules/eth.ts
@@ -72,7 +72,7 @@ type JsonRpcBlock = {
   gasLimit: string // the maximum gas allowed in this block.
   gasUsed: string // the total used gas by all transactions in this block.
   timestamp: string // the unix timestamp for when the block was collated.
-  transactions: string[] // Array of serialized transaction objects, or 32 Bytes transaction hashes depending on the last given parameter.
+  transactions: string[] | JsonTx[] // Array of transaction objects, or 32 Bytes transaction hashes depending on the last given parameter.
   uncles: string[] // Array of uncle hashes
   baseFeePerGas?: string // If EIP-1559 is enabled for this block, returns the base fee per gas
 }
@@ -141,7 +141,14 @@ const jsonRpcBlock = async (
 
   let transactions
   if (includeTransactions) {
-    transactions = block.transactions.map((tx) => bufferToHex(tx.serialize()))
+    transactions = block.transactions.map((tx) => {
+      const transaction = tx.toJSON()
+      return {
+        ...transaction,
+        input: transaction.data,
+        gas: transaction.gasLimit,
+      }
+    })
   } else {
     transactions = block.transactions.map((tx) => bufferToHex(tx.hash()))
   }


### PR DESCRIPTION
This PR aims to make the `eth_getBlockByNumber` return an array of transactions when `true` is passed as the second parameter; also, it returns `input` instead of `data` and `gas` instead of `gasLimit` as this is what is expected based on the [JSON-RPC Specs](https://github.com/ethereum/execution-apis/blob/main/src/schemas/transaction.json#L141-L176)